### PR TITLE
Pipeline Failed After Job Fixed

### DIFF
--- a/java-maven-sonar-argocd-helm-k8s/spring-boot-app/JenkinsFile
+++ b/java-maven-sonar-argocd-helm-k8s/spring-boot-app/JenkinsFile
@@ -56,7 +56,8 @@ pipeline {
                     git config user.email "abhishek.xyz@gmail.com"
                     git config user.name "Abhishek Veeramalla"
                     BUILD_NUMBER=${BUILD_NUMBER}
-                    sed -i "s/replaceImageTag/${BUILD_NUMBER}/g" java-maven-sonar-argocd-helm-k8s/spring-boot-app-manifests/deployment.yml
+                    imageTag=$(grep -oP '(?<=spring-docker:)[^ ]+' deployment.yml)
+                    sed -i "s/spring-docker:${imageTag}/spring-docker:${BUILD_NUMBER}/" deployment.yml
                     git add java-maven-sonar-argocd-helm-k8s/spring-boot-app-manifests/deployment.yml
                     git commit -m "Update deployment image to version ${BUILD_NUMBER}"
                     git push https://${GITHUB_TOKEN}@github.com/${GIT_USER_NAME}/${GIT_REPO_NAME} HEAD:main


### PR DESCRIPTION
Pipeline got failed after the First build because As per the Jenkinsfile, every time the sed command will look for replaceImageTag where it will be overridden by the very first job build.
So, the pipeline will fail the next time because it will try to match the same previous regex replaceImageTag which was not present.

In the new code, I have gathered the previous value that is stored in the deployment.yml and stored it in the imageTag variable and now, the sed command will try to find the imageTag value and then replace it with the ${BUILD_NUMBER}