### PR TITLE
Update JenkinsFile with updated "sed" command 

### DIFF
--- a/java-maven-sonar-argocd-helm-k8s/spring-boot-app/JenkinsFile
+++ b/java-maven-sonar-argocd-helm-k8s/spring-boot-app/JenkinsFile
@@ -56,7 +56,7 @@ pipeline {
                     git config user.email "abhishek.xyz@gmail.com"
                     git config user.name "Abhishek Veeramalla"
                     BUILD_NUMBER=${BUILD_NUMBER}
-                    sed -i "s/replaceImageTag/${BUILD_NUMBER}/g" java-maven-sonar-argocd-helm-k8s/spring-boot-app-manifests/deployment.yml
+                    sed -i "s/\\([^:]*:[^:]*:\\).*/\\1${BUILD_NUMBER}/" java-maven-sonar-argocd-helm-k8s/spring-boot-app-manifests/deployment.yml
                     git add java-maven-sonar-argocd-helm-k8s/spring-boot-app-manifests/deployment.yml
                     git commit -m "Update deployment image to version ${BUILD_NUMBER}"
                     git push https://${GITHUB_TOKEN}@github.com/${GIT_USER_NAME}/${GIT_REPO_NAME} HEAD:main


### PR DESCRIPTION
Replacing "sed" command in jenkinsfile with more suitable one which can be used multiple times because if we run the build more than one time after successfully building the image it will fail because earlier "Sed command is looking for the text "replaceImageTag" from the deployment.yaml file, which is not present after successful build because it was updated with version tag.

Now the sed command will just update the tag with the latest one, when the build run second time after success.

@iam-veeramalla 
sed -i "s/\\([^:]*:[^:]*:\\).*/\\1${BUILD_NUMBER}/" java-maven-sonar-argocd-helm-k8s/spring-boot-app-manifests/deployment.yml