### PR TITLE
permission issue on /var/run/docker.sock resolved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ usermod -aG docker ubuntu
 systemctl restart docker
 ```
 
+
+### To prevent pipeline builer failure (/var/run/docker.sock: connect: permission denied) due to permission issue on below file.
+```
+sudo chmod 666 /var/run/docker.sock
+```
+
+
 Once you are done with the above steps, it is better to restart Jenkins.
 
 ```


### PR DESCRIPTION
Faced below error while building first pipeline 

permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/node:16-alpine/json": dial unix /var/run/docker.sock: connect: permission denied