### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ java -version
 Now, you can proceed with installing Jenkins
 
 ```
-curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee \
-  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
-echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
-  https://pkg.jenkins.io/debian binary/ | sudo tee \
+sudo wget -O /usr/share/keyrings/jenkins-keyring.asc \
+  https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
+echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc]" \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
 sudo apt-get update
 sudo apt-get install jenkins


### PR DESCRIPTION
Unable to run Jenkins with previous commands. Observed following error. 

Jun 22 18:18:13 ubuntu systemd[1]: jenkins.service: Start request repeated too quickly. 
Jun 22 18:18:13 ubuntu systemd[1]: jenkins.service: Failed with result 'exit-code'. 
Jun 22 18:18:13 ubuntu systemd[1]: Failed to start Jenkins Continuous Integration Server.

Update with the commands from Jenkins official documentation. This worked for me and might help others installing with README.md file reference.