### PR TITLE
typo error correction for spring-boot-app, instead of sprint-boot-app,

### DIFF
--- a/java-maven-sonar-argocd-helm-k8s/spring-boot-app/README.md
+++ b/java-maven-sonar-argocd-helm-k8s/spring-boot-app/README.md
@@ -10,8 +10,8 @@ This is a MVC architecture based application where controller returns a page wit
 Checkout the repo and move to the directory
 
 ```
-git clone https://github.com/iam-veeramalla/Jenkins-Zero-To-Hero/java-maven-sonar-argocd-helm-k8s/sprint-boot-app
-cd java-maven-sonar-argocd-helm-k8s/sprint-boot-app
+git clone https://github.com/iam-veeramalla/Jenkins-Zero-To-Hero/java-maven-sonar-argocd-helm-k8s/spring-boot-app
+cd java-maven-sonar-argocd-helm-k8s/spring-boot-app
 ```
 
 Execute the Maven targets to generate the artifacts


### PR DESCRIPTION
there is a typo error "sprint-boot-app" instead of spring-boot-app, i have made this small correction, kindly approve the PR, so that the error can be rectified.