### PR TITLE
Update README.md

### DIFF
--- a/java-maven-sonar-argocd-helm-k8s/spring-boot-app/README.md
+++ b/java-maven-sonar-argocd-helm-k8s/spring-boot-app/README.md
@@ -10,7 +10,9 @@ This is a MVC architecture based application where controller returns a page wit
 Checkout the repo and move to the directory
 
 ```
-git clone https://github.com/iam-veeramalla/Jenkins-Zero-To-Hero/java-maven-sonar-argocd-helm-k8s/sprint-boot-app
+git clone git@github.com:iam-veeramalla/Jenkins-Zero-To-Hero.git is the command to clone
+![image](https://github.com/user-attachments/assets/061c9a26-23bc-45e2-928a-8342dba8fb3a)
+
 cd java-maven-sonar-argocd-helm-k8s/sprint-boot-app
 ```
 


### PR DESCRIPTION
git clone command was incorrect the command needs to end with *.git repo.

No, the command is incorrect because you cannot clone a specific folder or subdirectory directly using git clone. The URL you provided includes a subdirectory path, which git clone does not support.

Correct way to clone the repository:
git clone https://github.com/iam-veeramalla/Jenkins-Zero-To-Hero.git Then, navigate to the desired subdirectory:


cd Jenkins-Zero-To-Hero/java-maven-sonar-argocd-helm-k8s/spring-boot-app/