### PR TITLE
Fixed incorrect Docker permission command structure (root user context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,14 @@ sudo apt install docker.io
 ### Grant Jenkins user and Ubuntu user permission to docker deamon.
 
 ```
+# Switch to root user
+
 sudo su - 
+```
+
+```
+# Now run the following as root
+
 usermod -aG docker jenkins
 usermod -aG docker ubuntu
 systemctl restart docker


### PR DESCRIPTION
The original code block merged `sudo su -` with `usermod` commands as if they could all run from the regular shell, which isn't correct.

- `sudo su -` should be run first to switch to root.
- The `usermod -aG docker <user>` and `systemctl restart docker` must be run as root **after switching**.
- I’ve separated these steps into two clearly labeled code blocks.

This improves clarity and avoids confusion for anyone following the setup guide.

Thanks for the great repo!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions for granting Jenkins and Ubuntu users permission to the Docker daemon, including explicit steps for switching to the root user before running commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->