### PR TITLE
Update Dockerfile

### DIFF
--- a/python-jenkins-argocd-k8s/Dockerfile
+++ b/python-jenkins-argocd-k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.11-slim
 RUN pip install django==3.2
 
 COPY . .


### PR DESCRIPTION
What happened?: The distutils library was a standard part of Python for many years, but it was officially removed in Python 3.12.

The Problem: Your Dockerfile starts with the line FROM python:3. This tag always pulls the latest stable version of Python 3, which is now 3.12 or newer. The project's code, however, requires django==3.2, an older version of Django that was written when distutils was still included and depends on it to work.

The Conflict: When Django 3.2 tries to run inside a modern Python 3.12+ container, it crashes because it can't find the distutils module it needs