### PR TITLE
Update Jenkins key URL in README as  the old GPG key is not wokring a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ java -version
 Now, you can proceed with installing Jenkins
 
 ```
-curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee \
-  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key | sudo tee /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+
 echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
   https://pkg.jenkins.io/debian binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null


### PR DESCRIPTION
as the gpk key expired on 26th march 2026, we need the latest gph key to add jenkins package to our package list.