### PR TITLE
fix: use debian-stable Jenkins repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ java -version
 Now, you can proceed with installing Jenkins
 
 ```
-curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee \
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key | sudo tee \
   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
 echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
-  https://pkg.jenkins.io/debian binary/ | sudo tee \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
   /etc/apt/sources.list.d/jenkins.list > /dev/null
 sudo apt-get update
 sudo apt-get install jenkins


### PR DESCRIPTION
## Description

This PR updates the Jenkins installation instructions to use the
`debian-stable` repository.

## Changes

- Updated the Jenkins repository URL from `debian` to `debian-stable`
- Updated the Jenkins signing key to `jenkins.io-2026.key`

## Testing

- Verified the Jenkins signing key URL returns HTTP 200
- Verified the `debian-stable` repository URL returns HTTP 200
- Ran `git diff --check` successfully

Fixes #554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Jenkins installation instructions to install `fontconfig` with OpenJDK 21.
  * Updated the Debian repository configuration to use the stable repository.
  * Updated the signing key reference to the 2026 key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->